### PR TITLE
Remove SoundCloud Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source :rubygems
 
-gem 'soundcloud'
 gem 'audite'
 
 group 'test' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,23 +2,9 @@ GEM
   remote: http://rubygems.org/
   specs:
     audite (0.3.0)
-    hashie (1.2.0)
-    httmultiparty (0.3.8)
-      httparty (>= 0.7.3)
-      multipart-post
-    httparty (0.10.2)
-      multi_json (~> 1.0)
-      multi_xml (>= 0.5.2)
     metaclass (0.0.1)
     mocha (0.12.7)
       metaclass (~> 0.0.1)
-    multi_json (1.5.0)
-    multi_xml (0.5.2)
-    multipart-post (1.1.5)
-    soundcloud (0.3.1)
-      hashie
-      httmultiparty (>= 0.3)
-      httparty (>= 0.7.3)
 
 PLATFORMS
   ruby
@@ -26,4 +12,3 @@ PLATFORMS
 DEPENDENCIES
   audite
   mocha
-  soundcloud

--- a/lib/soundcloud2000/client.rb
+++ b/lib/soundcloud2000/client.rb
@@ -1,34 +1,50 @@
-require 'soundcloud'
 require 'net/http'
+require 'json'
 
 module Soundcloud2000
   class Client
+    DEFAULT_LIMIT = 50
+
+    attr_reader :client_id
+
     def initialize(client_id)
-      @client = Soundcloud.new(client_id: client_id)
+      @client_id = client_id
     end
 
-    def resolve(path)
-      @client.get('/resolve', :url => "http://soundcloud.com/#{path}")
-    rescue Soundcloud::ResponseError
+    def tracks(page = 1, limit = DEFAULT_LIMIT)
+      get('/tracks', offset: (page - 1) * limit, limit: limit)
     end
 
-    def get(*args)
-      @client.get(*args)
+    def resolve(permalink)
+      res = get('/resolve', url: "http://soundcloud.com/#{permalink}")
+      if location = res['location']
+        get URI.parse(location).path
+      end
     end
 
-    def client_id
-      @client.client_id
+    def uri_escape(params)
+      URI.escape(params.collect{|k,v| "#{k}=#{v}"}.join('&'))
+    end
+
+    def request(type, path, params={})
+      params[:client_id] = client_id
+      params[:format] = 'json'
+
+      Net::HTTP.start('api.soundcloud.com', 443, :use_ssl => true) do |http|
+        http.request(type.new("#{path}?#{uri_escape params}"))
+      end
+    end
+
+    def get(path, params={})
+      JSON.parse(request(Net::HTTP::Get, path, params).body)
     end
 
     def location(url)
-      uri = URI.parse(url + '?client_id=' + client_id)
-      Net::HTTP.get_response(uri) do |res|
-        if res.code == '302'
-          return res.header['Location']
-        end
+      uri = URI.parse(url)
+      res = request(Net::HTTP::Get, uri.path)
+      if res.code == '302'
+        res.header['Location']
       end
-
-      nil
     end
 
   end

--- a/lib/soundcloud2000/controllers/track_controller.rb
+++ b/lib/soundcloud2000/controllers/track_controller.rb
@@ -3,6 +3,7 @@ require_relative '../time_helper'
 require_relative '../ui/table'
 require_relative '../ui/input'
 require_relative '../models/track_collection'
+require_relative '../models/user'
 
 module Soundcloud2000
   module Controllers
@@ -25,7 +26,7 @@ module Soundcloud2000
             @tracks.load_more if @view.bottom?
           when :u
             permalink = UI::Input.getstr('Change to SoundCloud user: ')
-            @tracks.user = @client.resolve(permalink)
+            @tracks.user = Models::User.new(@client.resolve(permalink))
           end
         end
       end

--- a/lib/soundcloud2000/models/user.rb
+++ b/lib/soundcloud2000/models/user.rb
@@ -14,6 +14,9 @@ module Soundcloud2000
         @hash['username']
       end
 
+      def uri
+        @hash['uri']
+      end
     end
   end
 end


### PR DESCRIPTION
The soundcloud gem has unnecessary dependencies and loads too many libraries, so I would like to remove it completely to have the audite gem as single dependency. I'm currently trying to package the app as a standalone app, so this would help a lot.
