### PR TITLE
listen to the favorites of a user

### DIFF
--- a/lib/soundcloud2000/application.rb
+++ b/lib/soundcloud2000/application.rb
@@ -71,7 +71,7 @@ module Soundcloud2000
       case key
       when :left, :right, :space, :s
         @player_controller.events.trigger(:key, key)
-      when :down, :up, :enter, :u
+      when :down, :up, :enter, :u, :f
         @track_controller.events.trigger(:key, key)
       end
     end

--- a/lib/soundcloud2000/controllers/track_controller.rb
+++ b/lib/soundcloud2000/controllers/track_controller.rb
@@ -27,6 +27,15 @@ module Soundcloud2000
           when :u
             permalink = UI::Input.getstr('Change to SoundCloud user: ')
             @tracks.user = Models::User.new(@client.resolve(permalink))
+            @tracks.collection_to_load = :user
+            @tracks.clear_and_replace
+          when :f
+            if @tracks.user.nil?
+              permalink = UI::Input.getstr('Change to favorites from SoundCloud user: ')
+              @tracks.user = Models::User.new(@client.resolve(permalink))
+            end
+            @tracks.collection_to_load = :favorites
+            @tracks.clear_and_replace
           end
         end
       end

--- a/lib/soundcloud2000/ui/input.rb
+++ b/lib/soundcloud2000/ui/input.rb
@@ -13,6 +13,7 @@ module Soundcloud2000
         ' '                => :space,
         's'                => :s,
         'u'                => :u,
+        'f'                => :f
       }
 
       def self.get(delay = 0)


### PR DESCRIPTION
hi, again! :)

usually i listen to the favs from my friends. i really needed that feature, maybe you like it too and it can be merged.

this feature is bind to the 'f' key.
if you never navigated to a user before it asks for the username otherwise it uses the last known user. i'm not sure about this behavior but it worked best for me. i tried asking for the username every time but it got on my nerves after a short time.

i had to change some of the internals in TrackCollection, at the moment TrackCollection can only handle the user tracks and the most recent tracks (without scope) this introduces a new state inside TrackCollection called 'collection_to_load'. maybe its better not to reuse the TrackCollection but since you did it with the user and recent tracks i followed the schema.

have a good night
ben
