### PR TITLE
use a system-wide logger

### DIFF
--- a/lib/soundcloud2000/application.rb
+++ b/lib/soundcloud2000/application.rb
@@ -20,7 +20,6 @@ module Soundcloud2000
     include Views
 
     def initialize(client)
-      @logger = Logger.new('debug.log')
       $stderr.reopen("debug.log", "w")
       @canvas = UI::Canvas.new
 
@@ -28,7 +27,7 @@ module Soundcloud2000
           UI::Rect.new(0, 0, Curses.cols, Curses.lines)))
 
       @player_controller = PlayerController.new(PlayerView.new(
-          UI::Rect.new(0, 0, Curses.cols, 5)), client, @logger)
+          UI::Rect.new(0, 0, Curses.cols, 5)), client)
 
       @track_controller = TrackController.new(TracksTable.new(
           UI::Rect.new(0, 5, Curses.cols, Curses.lines - 5)), client)
@@ -82,6 +81,10 @@ module Soundcloud2000
 
     def stop?
       @stop == true
+    end
+
+    def self.logger
+      @logger ||= Logger.new('debug.log')
     end
 
   end

--- a/lib/soundcloud2000/controllers/player_controller.rb
+++ b/lib/soundcloud2000/controllers/player_controller.rb
@@ -6,11 +6,11 @@ module Soundcloud2000
   module Controllers
     class PlayerController < Controller
 
-      def initialize(view, client, logger)
+      def initialize(view, client)
         super(view)
 
         @client = client
-        @player = Models::Player.new(logger)
+        @player = Models::Player.new
 
         @player.events.on(:progress) do
           @view.render

--- a/lib/soundcloud2000/download_thread.rb
+++ b/lib/soundcloud2000/download_thread.rb
@@ -5,8 +5,7 @@ module Soundcloud2000
   class DownloadThread
     attr_reader :events, :url, :progress, :total, :file
 
-    def initialize(logger, url, filename)
-      @logger = logger
+    def initialize(url, filename)
       @events = Events.new
       @url = URI.parse(url)
       @file = File.open(filename, "w")
@@ -15,7 +14,7 @@ module Soundcloud2000
     end
 
     def log(s)
-      @logger.debug("DownloadThread #{s}")
+      Soundcloud2000::Application.logger.debug("DownloadThread #{s}")
     end
 
     def start!

--- a/lib/soundcloud2000/models/player.rb
+++ b/lib/soundcloud2000/models/player.rb
@@ -6,8 +6,7 @@ module Soundcloud2000
     class Player
       attr_reader :track, :events
 
-      def initialize(logger)
-        @logger = logger
+      def initialize
         @track = nil
         @events = Events.new
         @folder = File.expand_path("~/.soundcloud2000")
@@ -59,7 +58,7 @@ module Soundcloud2000
 
         if !File.exist?(@file) || track.duration / 1000 < length_in_seconds * 0.95
           File.unlink(@file) rescue nil
-          @download = DownloadThread.new(@logger, location, @file)
+          @download = DownloadThread.new(location, @file)
         else
           @download = nil
         end
@@ -69,7 +68,7 @@ module Soundcloud2000
       end
 
       def log(*args)
-        @logger.debug 'Player: ' + args.join(" ")
+        Soundcloud2000::Application.logger.debug 'Player: ' + args.join(" ")
       end
 
       def level


### PR DESCRIPTION
using a system-wide logger instead of passing the logger object around, which gets messy over time.
