### PR TITLE
Fixing issue #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ library to compile the native extensions.
 
     brew install portaudio
     brew install mpg123
+    brew install curses    
     gem install soundcloud2000
 
 ### Debian / Ubuntu


### PR DESCRIPTION
- adding an instruction for OS X 10.9.3, Ruby 2.1
