### PR TITLE
specify dependencies properly.

### DIFF
--- a/soundcloud2000.gemspec
+++ b/soundcloud2000.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "json"
-  s.add_dependency "audite"
-  s.add_dependency "curses"
+  s.add_runtime_dependency "json"
+  s.add_runtime_dependency "audite"
+  s.add_runtime_dependency "curses"
 
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"


### PR DESCRIPTION
I tried to install this gem and run it as per the instructions in the README but quickly got an error that said:

``` shell
`require': cannot load such file -- curses (LoadError)
```

So i took a peek at the gemspec and noticed that curses dependency was specified incorrectly. I couldn't find a "add_dependency" configuration in the Specification Reference but there is an [add_runtime_dependency](http://guides.rubygems.org/specification-reference/#add_runtime_dependency).
