### PR TITLE
Player: fix cache comparison operator

### DIFF
--- a/lib/soundcloud2000/models/player.rb
+++ b/lib/soundcloud2000/models/player.rb
@@ -55,7 +55,7 @@ module Soundcloud2000
       def load(track, location, &block)
         @file = "#{@folder}/#{track.id}.mp3"
 
-        if !File.exist?(@file) || track.duration / 1000 < length_in_seconds * 0.95
+        if !File.exist?(@file) || track.duration / 1000 > length_in_seconds * 0.95
           File.unlink(@file) rescue nil
           @download = DownloadThread.new(location, @file)
         else


### PR DESCRIPTION
It looks like the comparison is the wrong way around when checking whether the cache is valid. It should presumably be checking if the cached copy's length is shorter than the canonical duration, not the other way around.

Fixes #72.
