### PR TITLE
fix empty track list crash

### DIFF
--- a/lib/soundcloud2000/client.rb
+++ b/lib/soundcloud2000/client.rb
@@ -5,10 +5,12 @@ module Soundcloud2000
   class Client
     DEFAULT_LIMIT = 50
 
-    attr_reader :client_id
+    attr_reader :client_id, :user
+    attr_writer :user
 
     def initialize(client_id)
       @client_id = client_id
+      @current_user = nil
     end
 
     def tracks(page = 1, limit = DEFAULT_LIMIT)

--- a/lib/soundcloud2000/controllers/player_controller.rb
+++ b/lib/soundcloud2000/controllers/player_controller.rb
@@ -59,9 +59,12 @@ module Soundcloud2000
       end
 
       def play(track)
-        location = @client.location(track.stream_url)
-
-        @player.play(track, location)
+        unless track == nil
+          location = @client.location(track.stream_url)
+          @player.play(track, location)
+        else
+          UI::Input.input_line_out("No track currently selected. Use f to switch to #{@client.user.username}'s favorites, or s to switch to their playlists/sets.")
+        end
       end
 
     end

--- a/lib/soundcloud2000/controllers/track_controller.rb
+++ b/lib/soundcloud2000/controllers/track_controller.rb
@@ -25,7 +25,7 @@ module Soundcloud2000
             @view.down
             @tracks.load_more if @view.bottom?
           when :u
-            @tracks.user = fetch_user_with_message('Change to SoundCloud user: ')
+            @tracks.user = @client.current_user = fetch_user_with_message('Change to SoundCloud user: ')
             @tracks.collection_to_load = :user
             @tracks.clear_and_replace
           when :f

--- a/lib/soundcloud2000/ui/input.rb
+++ b/lib/soundcloud2000/ui/input.rb
@@ -35,6 +35,7 @@ module Soundcloud2000
 
       def self.getstr(prompt)
         Curses.setpos(Curses.lines - 1, 0)
+        Curses.clrtoeol()
         Curses.addstr(prompt)
         Curses.echo
         result = Curses.getstr
@@ -46,8 +47,8 @@ module Soundcloud2000
 
       def self.input_line_out(output)
         Curses.setpos(Curses.lines - 1, 0)
+        Curses.clrtoeol()
         Curses.attron(Color.get(:red)) { Curses.addstr(output) }
-        Curses.echo
       end
     end
   end


### PR DESCRIPTION
app would crash if you hit 'enter' on an empty track list (replicate by going to an invalid user and hitting enter, the app was assuming it was on a track and would try to call .stream_url on nil)

also made .current_user available on @client
as we needed it inside of our player controller to know who we're currently viewing, 

should probably refactor it out of @tracks completely. 
@tracks belong to the current_user so it doesn't really 
make sense to have the object constructed the other way around.

also changed .getstr and line out to clear their lines to avoid gross text overlapping