### PR TITLE
Added 'xcode-select --install' to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ library to compile the native extensions.
 
 ### OSX
 
+    xcode-select --install
     brew install portaudio
     brew install mpg123
     gem install soundcloud2000


### PR DESCRIPTION
fix for Mac OS X by @zdrummond in issue #69