### PR TITLE
Fix navigation

### DIFF
--- a/lib/soundcloud2000/client.rb
+++ b/lib/soundcloud2000/client.rb
@@ -20,7 +20,9 @@ module Soundcloud2000
 
     def resolve(permalink)
       res = get('/resolve', url: "http://soundcloud.com/#{permalink}")
-      get URI.parse(location).path if location == res['location']
+      if res['location']
+        get URI.parse(res['location']).path
+      end
     end
 
     def uri_escape(params)

--- a/lib/soundcloud2000/controllers/track_controller.rb
+++ b/lib/soundcloud2000/controllers/track_controller.rb
@@ -32,7 +32,7 @@ module Soundcloud2000
               @tracks.clear_and_replace
             end
           when :f
-            @client.current_user = fetch_user_with_message('Change to SoundCloud user: ') if @client.current_user.nil?
+            @client.current_user = fetch_user_with_message('Change to SoundCloud user\'s favourites: ') if @client.current_user.nil?
             unless @client.current_user.nil?
               @tracks.collection_to_load = :favorites
               @tracks.clear_and_replace


### PR DESCRIPTION
* A lint autocorrected `if location = res['location']` but it's the ol' `if` statement returning a value which is true hullaballoo
* Changing it to the intended logic: Only try to resolve if the path given is a real path
* So it was a mixture of code that worked by co-incidence and misnamed variables

Before this change, all usage of keys to fetch user, favourites or playlists fails as this gif demonstrates:

![zu2xdpfyal](https://cloud.githubusercontent.com/assets/1064715/11901051/5aa383c8-a5a1-11e5-8665-df86549464f8.gif)

After this change, all is well:
![soundcloud2000](https://cloud.githubusercontent.com/assets/1064715/16889122/1fc8bab2-4adc-11e6-883f-b6b72158134d.gif)

I also changed the prompt to reflect what we're doing (checking favourites, rather than a user)


Closes #88 