### PR TITLE
Fixes time header

### DIFF
--- a/lib/soundcloud2000/time_helper.rb
+++ b/lib/soundcloud2000/time_helper.rb
@@ -17,7 +17,7 @@ module Soundcloud2000
 
       parts.shift if parts.first.zero?
 
-      [parts.first, *parts[1..-1].map { |part| "%02d#{part}" }].join('.')
+      [parts.first, *parts[1..-1].map { |part| format('%02d', part) }].join('.')
     end
   end
 end


### PR DESCRIPTION
Looks like an error from a listing autofix, fixed to both follow rubocop errors and give correct timing fixes

Before:

```
Length           
3.%02d30        
```

After:

```
Length   
3.30     
```
